### PR TITLE
Use direct Calendar API fetch and harden logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Google Calendar → Discord 通知 (GAS + clasp)
 
-共有カレンダーの新規・更新・キャンセルを定期ポーリングで検知し、Discord の Webhook に投稿する Google Apps Script プロジェクトです。Advanced Google Services の Calendar v3 を利用します。
+共有カレンダーの新規・更新・キャンセルを定期ポーリングで検知し、Discord の Webhook に投稿する Google Apps Script プロジェクトです。Google Calendar API (v3) の REST エンドポイントを直接呼び出します。
 
 ## 構成
 
-- `gas/appsscript.json`: マニフェスト（Calendar v3 / スコープ定義 / タイムゾーン）
+- `gas/appsscript.json`: マニフェスト（スコープ定義 / タイムゾーン）
 - `gas/Code.gs`: 差分取得・Discord 送信・トリガー
 - `gas/Utils.gs`: メッセージ整形ユーティリティ
 
@@ -43,10 +43,10 @@ clasp push
 clasp open
 ```
 
-## Advanced Services 有効化
+## Google Calendar API 有効化
 
-- スクリプトエディタ上部の「サービス」から「Calendar API (v3)」を追加
-- 必要に応じて、右上「プロジェクトの設定」→「Google Cloud プロジェクトを表示」で GCP 側の「Google Calendar API」も有効化
+- Apps Script エディタ右上の「プロジェクトの設定」→「Google Cloud プロジェクトを表示」で紐づく Cloud プロジェクトを開き、Google Calendar API を有効化してください。
+- 既存のプロジェクトにリンクしていない場合は、同画面の「Google Cloud プロジェクトを変更」から任意のプロジェクトに関連付けて API を有効化します。
 
 ## Script Properties（必須）
 
@@ -72,6 +72,6 @@ clasp open
 ## トラブルシュート
 
 - 承認で止まる: GCP の OAuth 同意画面で実行アカウントをテストユーザーに追加
-- `Calendar is not defined`: 「サービス」で Calendar API (v3) を追加
+- `Calendar API error (...)`: Cloud プロジェクトで Google Calendar API が有効か確認し、必要なら再承認
 - 403（スコープ不足）: `appsscript.json` に `calendar.readonly` と `script.external_request` が含まれているか確認し、手動実行で再承認
 - 投稿されない: トリガー実行履歴とログ（`Calendar diff: ...`）を確認

--- a/gas/Utils.gs
+++ b/gas/Utils.gs
@@ -8,7 +8,7 @@ function buildDiscordMessage(kind, ev, tz) {
   const desc = ev.description ? `\n- メモ: ${truncate(ev.description, 400)}` : '';
 
   const timeText = buildTimeText(ev, tz);
-  const rid = ev.recurringEventId ? ` (繰り返しインスタンス)` : '';
+  const rid = ev.recurringEventId ? ' (繰り返しインスタンス)' : '';
 
   return [
     `【Googleカレンダー更新】${kind}${rid}`,
@@ -24,9 +24,7 @@ function buildTimeText(ev, tz) {
   const fmt = (d) => Utilities.formatDate(d, tz, 'yyyy/MM/dd(EEE) HH:mm');
   const allDayFmt = (d) => Utilities.formatDate(d, tz, 'yyyy/MM/dd(EEE)');
 
-  // All-day: date, Timed: dateTime
   if (ev.start && ev.start.date) {
-    // Google Calendar の all-day は終了日に+1される仕様
     if (ev.end && ev.end.date) {
       const s = new Date(ev.start.date);
       const e = new Date(new Date(ev.end.date).getTime() - 1);
@@ -42,7 +40,6 @@ function buildTimeText(ev, tz) {
     const s = new Date(ev.start.dateTime);
     const e = ev.end && ev.end.dateTime ? new Date(ev.end.dateTime) : null;
     if (!e) return `${fmt(s)} 〜`;
-    // 同日なら時刻のみ表示簡略
     const sameDay = Utilities.formatDate(s, tz, 'yyyy/MM/dd') === Utilities.formatDate(e, tz, 'yyyy/MM/dd');
     if (sameDay) {
       const sd = Utilities.formatDate(s, tz, 'yyyy/MM/dd(EEE)');
@@ -59,10 +56,5 @@ function buildTimeText(ev, tz) {
 function truncate(text, max) {
   if (!text) return '';
   if (text.length <= max) return text;
-  return text.slice(0, max) + '…';
+  return `${text.slice(0, max)}…`;
 }
- 
-/**
- * Discord メチE��ージを構篁E */
-function buildDiscordMessage(kind, ev, tz) {
-  const title = ev.summary || '(無顁E';

--- a/gas/appsscript.json
+++ b/gas/appsscript.json
@@ -5,18 +5,5 @@
   "oauthScopes": [
     "https://www.googleapis.com/auth/calendar.readonly",
     "https://www.googleapis.com/auth/script.external_request"
-  ],
-  "dependencies": {
-    "enabledAdvancedServices": [
-      {
-        "userSymbol": "Calendar",
-        "serviceId": "calendar",
-        "version": "v3"
-      }
-    ]
-  }
+  ]
 }
- {
-   "timeZone": "Asia/Tokyo",
-   "exceptionLogging": "STACKDRIVER",
-   "runtimeVersion": "V8",


### PR DESCRIPTION
## Summary
- switch calendar polling to direct REST requests with ScriptApp OAuth tokens
- add robust logging helpers and improved error reporting for Discord webhook failures
- reset invalid LAST_CHECKED_AT values and refresh documentation/manifest to drop advanced service dependency

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cf8f4da7ec832597ba7c24a3368aee